### PR TITLE
Fix: Grid missing on Magento 2.3.x

### DIFF
--- a/Block/Adminhtml/Report/Grid.php
+++ b/Block/Adminhtml/Report/Grid.php
@@ -28,11 +28,11 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
         /** @var $genericCollection \DEG\CustomReports\Model\GenericReportCollection */
         $genericCollection = $customReport->getGenericReportCollection();
         $columnList = $this->getColumnListFromCollection($genericCollection);
-        if (count($columnList)) {
+        //if (count($columnList)) {
             $this->addColumnSet($columnList);
             $this->addGridExportBlock();
             $this->setCollection($genericCollection);
-        }
+        //}
         parent::_prepareLayout();
     }
 


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in app/code/DEG/CustomReports/Block/Adminhtml/Report/Grid.php on line 31 [] []