### PR TITLE
Remove PHP requirements from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,6 @@
     "OSL-3.0",
     "AFL-3.0"
   ],
-  "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
-  },
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {


### PR DESCRIPTION
It doesn't make sense to add PHP requirements in composer.json as they are now: (php 5.5, 5.6, 7.0, 7.1)

- this configuration prevents from using the package in PHP 7.2
- Magento 2 doesnt support php 5.5. or 5.6, so it doesnt make sense to specify it here
- This is M2 module, so we should rely on magento PHP requirements
for every new PHP version this line needs to be updated
