### PR TITLE
Fix implicit nullable parameter deprecations for PHP 8.4

### DIFF
--- a/Model/CustomReport.php
+++ b/Model/CustomReport.php
@@ -42,8 +42,8 @@ class CustomReport extends AbstractModel implements CustomReportInterface, Ident
         Context $context,
         Registry $registry,
         GenericReportCollectionFactory $genericReportCollectionFactory,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/Model/GenericReportCollection.php
+++ b/Model/GenericReportCollection.php
@@ -28,8 +28,8 @@ class GenericReportCollection extends AbstractDb
         EntityFactoryInterface $entityFactory,
         Logger $logger,
         FetchStrategyInterface $fetchStrategy,
-        AdapterInterface $connection = null,
-        ResourceConnection $resourceConnection = null
+        ?AdapterInterface $connection = null,
+        ?ResourceConnection $resourceConnection = null
     ) {
         $resourceConnection = $resourceConnection ?: ObjectManager::getInstance()->get(ResourceConnection::class);
 


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters (typed parameters with a `null` default but no explicit nullable type). Loading these classes on PHP 8.4 raises:

```
Deprecated Functionality: DEG\CustomReports\Model\GenericReportCollection::__construct(): Implicitly marking parameter $resourceConnection as nullable is deprecated, the explicit nullable type must be used instead
```

In Magento developer mode this deprecation is escalated to an exception by `Magento\Framework\App\ErrorHandler`, which breaks `setup:di:compile` (proxy/repository code generation reflects these constructors).

This PR adds the explicit `?` nullable type to the four affected parameters:

- `Model/CustomReport.php`: `$resource`, `$resourceCollection`
- `Model/GenericReportCollection.php`: `$connection`, `$resourceConnection`

No behavior change — the explicit nullable type is identical to the previous implicit semantics and remains compatible with PHP 7.1+.

Related: #51