### PR TITLE
Fix implicit nullable parameter deprecations for PHP 8.4 (3.x)

### DIFF
--- a/Model/AutomatedExport/ExportType/LocalFileStreamsHandler.php
+++ b/Model/AutomatedExport/ExportType/LocalFileStreamsHandler.php
@@ -118,7 +118,7 @@ class LocalFileStreamsHandler extends DataObject implements StreamHandlerInterfa
     /**
      * @throws FileSystemException
      */
-    public function exportReportChunk(array $dataToWrite, string $rowType = null)
+    public function exportReportChunk(array $dataToWrite, ?string $rowType = null)
     {
         foreach ($this->exportStreams as $exportStream) {
             switch ($exportStream->getFileType()) {

--- a/Model/GenericReportCollection.php
+++ b/Model/GenericReportCollection.php
@@ -46,7 +46,7 @@ class GenericReportCollection extends AbstractDb
         EntityFactoryInterface $entityFactory,
         Logger $logger,
         FetchStrategyInterface $fetchStrategy,
-        ResourceConnection $resourceConnection = null
+        ?ResourceConnection $resourceConnection = null
     ) {
         $resourceConnection = $resourceConnection ?: ObjectManager::getInstance()->get(ResourceConnection::class);
 

--- a/Model/Mail/Template/TransportBuilder.php
+++ b/Model/Mail/Template/TransportBuilder.php
@@ -30,11 +30,11 @@ class TransportBuilder extends MagentoTransportBuilder
         TransportInterfaceFactory $mailTransportFactory,
         protected MessageBuilderFactory $messageBuilderFactory,
         protected MimePartInterfaceFactory $mimePartFactory,
-        MessageInterfaceFactory $messageFactory = null,
-        EmailMessageInterfaceFactory $emailMessageInterfaceFactory = null,
-        MimeMessageInterfaceFactory $mimeMessageInterfaceFactory = null,
-        MimePartInterfaceFactory $mimePartInterfaceFactory = null,
-        AddressConverter $addressConverter = null
+        ?MessageInterfaceFactory $messageFactory = null,
+        ?EmailMessageInterfaceFactory $emailMessageInterfaceFactory = null,
+        ?MimeMessageInterfaceFactory $mimeMessageInterfaceFactory = null,
+        ?MimePartInterfaceFactory $mimePartInterfaceFactory = null,
+        ?AddressConverter $addressConverter = null
     ) {
         parent::__construct(
             $templateFactory,


### PR DESCRIPTION
Same class of fix as #52, but against the `3.x` release line (tags 3.0.0–3.1.4), which is what composer installs.

PHP 8.4 deprecates implicitly nullable parameters (typed parameters defaulting to `null` without an explicit `?`). In Magento developer mode the deprecation is escalated to an exception by `Magento\Framework\App\ErrorHandler`, breaking `setup:di:compile` — this is the failure reported in #51 (`TransportBuilder::__construct()`).

Fixed parameters:
- `Model/GenericReportCollection.php`: `$resourceConnection`
- `Model/Mail/Template/TransportBuilder.php`: `$messageFactory`, `$emailMessageInterfaceFactory`, `$mimeMessageInterfaceFactory`, `$mimePartInterfaceFactory`, `$addressConverter` (now matching the explicit nullable types of the core `Magento\Framework\Mail\Template\TransportBuilder` parent)

No behavior change; compatible with PHP 7.1+.

Fixes #51